### PR TITLE
fix: specify gitbook version to install when running npm i

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "documentation for npm Enterprise, npm's Enterprise offering",
   "main": "index.js",
   "scripts": {
-    "install": "gitbook install",
+    "install": "gitbook fetch 3.2.0 && gitbook install",
     "prestart": "npm run build",
     "start": "gitbook serve",
     "build": "npm run build:scripts && npm run build:styles && npm run concat:styles && gitbook build",


### PR DESCRIPTION
Otherwise an unsuspecting soul like myself might end up running on the wrong version of GitBook, which can have a much different look & feel than the deployment target.

Side note: if it doesn't break the deployment script, we may want to also add the generated `styles/website.css` file to `.gitignore`
