### PR TITLE
docs: updating the azure tutorial

### DIFF
--- a/up-and-running/platforms/azure.md
+++ b/up-and-running/platforms/azure.md
@@ -10,8 +10,9 @@ To get npm Enterprise up and running on Microsoft Azure, you first need:
 ...then we'll need to:
 
 1. Set up and deploy an Ubuntu 14.04 LTS VM
-2. Run the npmO deploy script
-3. Set up endpoints for the admin panel, registry, and website
+2. install Node.js and npm
+3. install npm Enterprise itself
+4. Set up endpoints for the admin panel, registry, and website
 
 Let's get started!
 
@@ -29,30 +30,29 @@ While setting this up, make sure to:
 Feel free to make any other configurations you wish. Once you are set, deploy
 your VM and move on to Step 2!
 
-## Step 2: Install npm Enterprise
+## Step 2: Install npm and Node.js
 
-Now that you have a VM deployed, let's install the npm Enterprise (`npmo`) tool.
+Now that you have a VM deployed, let's install npm and Node.js
 
-1. SSH into your VM
-2. `curl https://raw.githubusercontent.com/ashleygwilliams/npmo-deploy/master/deploy.sh | sh`
-3. Let it run! It can take a minute or two, depending on the specs of your VM.
+```bash
+curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+sudo apt-get install -y nodejs
+sudo npm i -g npm@latest
+node -v && npm -v
+```
 
-  This script:
+## Step 3: Install npm Enterprise itself
 
-  - updates `apt-get`
-  - installs `curl` via `apt-get`
-  - installs Node.js, via [NodeSource]
-  - updates npm
-  - displays Node.js and npm versions
-  - installs `npmo` globally as the root user, via npm
+```bash
+sudo npm i npme -g --unsafe
+```
 
-
-4. To confirm that it worked, type `npmo`. If the install succeeded you should see the
-   `npmo help` screen, which looks like this:
+To confirm that it worked, type `npme`. If the install succeeded you should see the
+`npme help` screen, which looks like this:
 
   ![npmo help in terminal](/gitbook/images/npmo-help.png)
 
-## Step 3: Set up Endpoints
+## Step 4: Set up Endpoints
 
 There are now 4 web services running on 4 ports on your VM. In order to access these
 outside of the VM, we'll need to create rules to allow them to be accessed. The ports
@@ -63,7 +63,6 @@ we need to configure are:
 | Administrator Panel       | 8800  |
 | Registry                  | 8080  |
 | Website                   | 8081  |
-| Authentication Endpoints  | 8082  |
 
 [npm user account]: https://www.npmjs.com/signup
 [free trial]: https://www.npmjs.com/enterprise#free-trial

--- a/up-and-running/platforms/azure.md
+++ b/up-and-running/platforms/azure.md
@@ -4,7 +4,6 @@
 
 To get npm Enterprise up and running on Microsoft Azure, you first need:
 
-- An [npm user account]
 - An npm Enterprise license. Get a [free trial] here!
 - A [Microsoft account] and an [Azure account]
 
@@ -53,7 +52,7 @@ Now that you have a VM deployed, let's install the npm Enterprise (`npmo`) tool.
 
   ![npmo help in terminal](/gitbook/images/npmo-help.png)
 
-## Step 3: Set up Endpoints 
+## Step 3: Set up Endpoints
 
 There are now 4 web services running on 4 ports on your VM. In order to access these
 outside of the VM, we'll need to create rules to allow them to be accessed. The ports


### PR DESCRIPTION
Updated the Azure tutorial, mainly removing all references to `npmo`. I've also opted to inline the bootstrap script: this is partially to remove the reference to `npmo` in this script, and partially to move the documentation closer to https://www.npmjs.com/enterprise-setup
