### PR TITLE
ci: build and deploy with just one version of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-- 4
-- 5
+- 6
 script:
 - npm run build
 after_success:


### PR DESCRIPTION
Since we auto-deploy to `gh-pages` on non-PR builds of `master`, there's no need to build on multiple versions of Node. Opted for Node 6 since:
1. it will enter Active LTS on 10/1/2016
2. it comes with npm 3 (Node 4 uses npm 2)
3. it's what I use locally :)
