### PR TITLE
docs: add page on Replication for Backups and HA

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,6 +25,7 @@
   * [Enterprise Add-Ons](tutorials/addons.md)
   * [Bitbucket Pipelines](tutorials/pipelines.md)
   * [Terminating SSL with NGINX](tutorials/nginx.md)
+  * [Replication for Backups and HA](tutorials/replication.md)
 * [Troubleshooting](troubleshooting/README.md)
   * [FAQ](troubleshooting/faq.md)
   * [npm Enterprise Won't Boot](troubleshooting/booting.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,7 +25,7 @@
   * [Enterprise Add-Ons](tutorials/addons.md)
   * [Bitbucket Pipelines](tutorials/pipelines.md)
   * [Terminating SSL with NGINX](tutorials/nginx.md)
-  * [Replication for Backups and HA](tutorials/replication.md)
+  * [Backups and HA](tutorials/backups-and-ha.md)
 * [Troubleshooting](troubleshooting/README.md)
   * [FAQ](troubleshooting/faq.md)
   * [npm Enterprise Won't Boot](troubleshooting/booting.md)

--- a/troubleshooting/faq.md
+++ b/troubleshooting/faq.md
@@ -114,7 +114,7 @@ Setting up a replica is easy:
 That's all there is to it, wait a few minutes and the secondary should be synced with the
 primary server.
 
-For more details, see [Replication for Backups and HA](../tutorials/replication.md).
+For more details, see replication for [Backups and HA](../tutorials/backups-and-ha.md).
 
 ## What's the difference between a scoped package and an unscoped package?
 

--- a/troubleshooting/faq.md
+++ b/troubleshooting/faq.md
@@ -91,6 +91,31 @@ sudo npm uninstall -g npmo
 sudo npm i -g --ignore-scripts npme
 ```
 
+## How do I replicate between two npm Enterprise instances?
+
+It's good practice to setup a second npm Enterprise as a replica of your primary npm Enterprise
+server. This gives you a hot spare to fallback to in the case of failure.
+
+Setting up a replica is easy:
+
+1. on your primary server copy the values of `Full URL of npm Enterprise registry`, and
+   `Secret used between services` (replication connects to the registry component
+    of npm Enterprise, which defaults to running on `:8080`).
+2. provision the secondary server and ensure that publication and installation is working
+  appropriately.
+3. Optionally, set `Publication Settings` to `Read Only` on the secondary server (this
+   will prevent users form accidentally publishing packages to it).
+4. on the secondary server:
+  * set `Upstream URL` to the value of `Full URL of npm Enterprise registry` on the primary.
+  * set `Upstream secret` to the value of `Secret used between services` on the primary.
+  * set `Policy to apply during replication` to `mirror` on the secondary server.
+5. `ssh` into the secondary server, and run `npme reset-follower`.
+
+That's all there is to it, wait a few minutes and the secondary should be synced with the
+primary server.
+
+For more details, see [Replication for Backups and HA](../tutorials/replication.md).
+
 ## What's the difference between a scoped package and an unscoped package?
 
 A scoped package has a scope (or namespace), which begins with an `@` symbol and is followed by a `/`, in the package name, e.g. `@scope/foo`. An unscoped package has no scope in the package name, e.g. `foo`. The scope is a permanent part of the package's name and identity, used in `package.json` and also in `require()` or `import` statements in code.
@@ -121,26 +146,3 @@ You are allowed to use as many scopes as you like with npm Enterprise. You could
 ## If I publish a package to my npm Enterprise registry, will it be published privately on the public registry too?
 
 No. Packages published to npm Enterprise are not published to an upstream registry, particularly not the public registry. One of the main reasons to use npm Enterprise is that you maintain complete control over the packages that you publish - they belong to you and they live _only_ on your server(s). Access to packages published to npm Enterprise is defined by your configured authentication/authorization provider, which is controlled by you or your organization. The access control used by the public registry is different and completely separate.
-
-## How do I replicate between two npm Enterprise instances?
-
-It's good practice to setup a second npm Enterprise as a replica of your primary npm Enterprise
-server. This gives you a hot spare to fallback to in the case of failure.
-
-Setting up a replica is easy:
-
-1. on your primary server copy the values of `Full URL of npm Enterprise registry`, and
-   `Secret used between services` (replication connects to the registry component
-    of npm Enterprise, which defaults to running on `:8080`).
-2. provision the secondary server and ensure that publication and installation is working
-  appropriately.
-3. Optionally, set `Publication Settings` to `Read Only` on the secondary server (this
-   will prevent users form accidentally publishing packages to it).
-4. on the secondary server:
-  * set `Upstream URL` to the value of `Full URL of npm Enterprise registry` on the primary.
-  * set `Upstream secret` to the value of `Secret used between services` on the primary.
-  * set `Policy to apply during replication` to `mirror` on the secondary server.
-5. `ssh` into the secondary server, and run `npme reset-follower`.
-
-That's all there is to it, wait a few minutes and the secondary should be synced with the
-primary server.

--- a/tutorials/backups-and-ha.md
+++ b/tutorials/backups-and-ha.md
@@ -1,4 +1,4 @@
-# Replication for Backups and HA
+# Backups and HA
 
 One nice thing about npm Enterprise is that replication is built into the product, and you can configure it using just the Settings page in the admin console UI. We typically recommend running at least one other npme instance as a live replica, which is easy to set up and makes restoration as simple as configuring your client to talk to a secondary instance if your primary instance goes down. This also makes it easy to set up a HA solution, where you could front the instances with a load balancer, directing all writes to the primary instance while balancing reads across many instances. In case of failure, reads/installs will still be available but writes/publishes will be unavailable until you can make a secondary instance the new primary by directing writes to it.
 

--- a/tutorials/replication.md
+++ b/tutorials/replication.md
@@ -1,0 +1,35 @@
+# Replication for Backups and HA
+
+One nice thing about npm Enterprise is that replication is built into the product, and you can configure it using just the Settings page in the admin console UI. We typically recommend running at least one other npme instance as a live replica, which is easy to set up and makes restoration as simple as configuring your client to talk to a secondary instance if your primary instance goes down. This also makes it easy to set up a HA solution, where you could front the instances with a load balancer, directing all writes to the primary instance while balancing reads across many instances. In case of failure, reads/installs will still be available but writes/publishes will be unavailable until you can make a secondary instance the new primary by directing writes to it.
+
+To configure another instance as a replica, use the "Upstream registry" section of the Settings in the admin console:
+
+- Set the **Upstream URL** to the registry URL (port 8080) of the primary instance
+- Set the **Upstream secret** to the **Secret used between services** of the primary instance
+- Set the **Policy to apply during replication** to `mirror`
+- Optionally set the **Publication Settings** to `Read Only` to prevent accidental publishes to the replica
+
+Please note that if you make these configuration changes after an instance has already been running, you should do one of the following on your replica instance:
+
+1. Run `npme reset-follower`
+2. Stop the services/containers via admin console Dashboard, remove or truncate the `sequence` file in your replica instance (located in your configured "Miscellaneous data files" directory), and then start the services/containers.
+
+This will ensure that your replica has the full set of package changes from the instance it's following.
+
+In this manner, you could set up multiple replicas of a single instance or daisy chain one replica behind another for redundancy. We do not limit the number of npm Enterprise instances you can run or the number of packages each instance holds - our license is only based on how many users benefit from your instances.
+
+Although it's not necessary, you may also wish to store manual snapshots for backup purposes in addition to running live replicas. The host directories you should snapshot are represented on the Settings page as the following:
+
+- **CouchDB storage path on host** which defaults to `/usr/local/lib/npme/couchdb`
+
+    CouchDB is used to hold package metadata for every package in your registry, including public and private packages. This is the directory that holds the critical db files representing this data.
+
+- **Package storage path on host** which defaults to `/usr/local/lib/npme/packages`
+
+    Each version of every package in your registry is stored as a tarball on the host file system. This is the root directory for all package tarballs.
+
+- **Miscellaneous data files** which defaults to `/usr/local/lib/npme/data`
+
+    The registry maintains some small files and runtime data to keep track of things like replication status and whitelist configuration. This is the directory that holds those files.
+
+If all live replicas happen to fail, it is possible to recreate a warm instance by restoring snapshots of these directories after a new install. All other data can be rebuilt from the files in these key directories.


### PR DESCRIPTION
New "Tutorials" page with content from https://gist.github.com/nexdrew/f00b16908743942196203b45abde70d8

Also added link to this page from the "How do I replicate between two npm Enterprise instances?" FAQ (which was moved in-page to match the TOC order).
