### PR TITLE
feat: added links to the workflow section

### DIFF
--- a/workflow/README.md
+++ b/workflow/README.md
@@ -3,3 +3,9 @@
 In this section we outline several common workflows, which represent
 a good starting point for your company once you get your npm Enterprise
 server up and running.
+
+* [Installing Packages](/workflow/installing-packages.md)
+* [Publishing Packages](/workflow/publishing-packages.md)
+* [Whitelisting Packages](/workflow/whitelisting.md)
+* [Mirroring the Public Registry](/workflow/mirroring.md)
+* [Integrating with Travis CI](/workflow/travis.md)


### PR DESCRIPTION
I've added links to the `Common Workflow` section, so that we can directly link to it as suggested by @nexdrew in https://github.com/npm/docs/pull/744
